### PR TITLE
Added includes to standard libraries

### DIFF
--- a/FTS3HTMLTokenizer.podspec
+++ b/FTS3HTMLTokenizer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FTS3HTMLTokenizer'
-  s.version      = '1.0.11'
+  s.version      = '1.1'
   s.summary      = 'FTS3 HTML Tokenizer'
   s.license      = 'MIT'
   s.author       = 'Stephan Heilner'

--- a/src/fts3_html_tokenizer.h
+++ b/src/fts3_html_tokenizer.h
@@ -18,6 +18,8 @@
 #include <ctype.h>
 #include "libstemmer.h"
 #include <sqlite3.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 int registerTokenizer(sqlite3 *db, char *zName);
 


### PR DESCRIPTION
Xcode 7.3 gave me issues about `malloc` and `sprintf` when building for iOS 9.3. Not sure if its the OS or an update in configuration that requires this. 
